### PR TITLE
Fix #4: remove leakage-prone target variables from training features

### DIFF
--- a/jobs/pipeline/src/pipeline/cli.py
+++ b/jobs/pipeline/src/pipeline/cli.py
@@ -39,12 +39,9 @@ def log(message: str) -> None:
 
 DEFAULT_FEATURE_LIST = [
   "company_status_clean",
-  "target_total_funding_eur",
   "last_funding_eur",
   "valuation_eur",
-  "target_rounds_num",
-  "stage_ordinal",
-  "has_funding"
+  "stage_ordinal"
 ]
 
 COLUMN_ALIASES = {

--- a/shared/config/feature_list.yml
+++ b/shared/config/feature_list.yml
@@ -1,9 +1,6 @@
 # Base feature list for MVP models
 features:
   - company_status_clean
-  - target_total_funding_eur
   - last_funding_eur
   - valuation_eur
-  - target_rounds_num
   - stage_ordinal
-  - has_funding


### PR DESCRIPTION
Fixes #4

This draft removes leakage-prone target-derived columns from the default training feature list:
- Removed `target_total_funding_eur`
- Removed `target_rounds_num`
- Removed `has_funding`

Updated in both:
- `jobs/pipeline/src/pipeline/cli.py` (`DEFAULT_FEATURE_LIST`)
- `shared/config/feature_list.yml`

Goal: avoid target leakage in baseline model training while keeping the change minimal and focused.
