### PR TITLE
Fix: Handle non-numeric values in 0_founders_number

### DIFF
--- a/jobs/analysis/src/correlation_analysis.py
+++ b/jobs/analysis/src/correlation_analysis.py
@@ -268,8 +268,7 @@ def main() -> None:
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     df = pd.read_csv(DATA_PATH, low_memory=False)
 
-    # Clean non-numeric values in 0_founders_number (e.g., '4+', 'Personne morale')
-    df["0_founders_number"] = df["0_founders_number"].replace({"4+": "4", "Personne morale": None})
+    df = clean_founders_number(df)
 
     print(f"Loaded {len(df)} rows, {len(df.columns)} columns")
 

--- a/jobs/analysis/src/data_utils.py
+++ b/jobs/analysis/src/data_utils.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import pandas as pd
+
+
+def clean_founders_number(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize non-numeric founders count values before numeric coercion."""
+    df["0_founders_number"] = df["0_founders_number"].replace({"4+": "4", "Personne morale": None})
+    return df

--- a/jobs/analysis/src/regression_analysis.py
+++ b/jobs/analysis/src/regression_analysis.py
@@ -36,6 +36,8 @@ import pandas as pd
 from scipy import stats as sp_stats
 
 import statsmodels.api as sm
+
+from data_utils import clean_founders_number
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 from statsmodels.stats.diagnostic import het_breuschpagan
 from statsmodels.discrete.discrete_model import NegativeBinomial
@@ -77,8 +79,7 @@ def load_and_prepare() -> pd.DataFrame:
     """Load dataset and prepare analysis-ready DataFrame."""
     df = pd.read_csv(DATA_PATH, low_memory=False)
 
-    # Clean non-numeric values in 0_founders_number (e.g., '4+', 'Personne morale')
-    df["0_founders_number"] = df["0_founders_number"].replace({"4+": "4", "Personne morale": None})
+    df = clean_founders_number(df)
 
     # Convert targets and numeric predictors
     for col in ["target_delta_1st_round", "target_total_funding", "target_rounds"] + NUMERIC_PREDICTORS:

--- a/jobs/analysis/src/robustness_checks.py
+++ b/jobs/analysis/src/robustness_checks.py
@@ -27,6 +27,8 @@ import numpy as np
 import pandas as pd
 from scipy import stats as sp_stats
 import statsmodels.api as sm
+
+from data_utils import clean_founders_number
 from statsmodels.stats.outliers_influence import variance_inflation_factor
 from statsmodels.stats.diagnostic import het_breuschpagan
 
@@ -53,8 +55,7 @@ REDUCED_NUMERIC = ["0_founders_number"]  # Drop 8_age_moyen (VIF=6.41, less theo
 def load_and_prepare() -> pd.DataFrame:
     df = pd.read_csv(DATA_PATH, low_memory=False)
 
-    # Clean non-numeric values in 0_founders_number (e.g., '4+', 'Personne morale')
-    df["0_founders_number"] = df["0_founders_number"].replace({"4+": "4", "Personne morale": None})
+    df = clean_founders_number(df)
     for col in ["target_delta_1st_round", "target_total_funding", "target_rounds"] + NUMERIC_PREDICTORS:
         df[col] = pd.to_numeric(df[col], errors="coerce")
     for col in BINARY_PREDICTORS:


### PR DESCRIPTION
Cleans '4+' → 4 and 'Personne morale' → NaN in all analysis scripts before numeric conversion. Prevents silent data corruption from pd.to_numeric(errors='coerce').

Closes #22