### PR TITLE
Draft: Issue #26 - Add sample size reporting table to EDA output

### DIFF
--- a/docs/issue-tracking/issue-26.md
+++ b/docs/issue-tracking/issue-26.md
@@ -2,10 +2,16 @@
 
 Status: Draft implementation plan
 
-## Scope
-- [ ] Reproduce issue
-- [ ] Implement fix
-- [ ] Add/adjust tests
-- [ ] Update docs/output artifacts
+## Acceptance criteria
+- [ ] Root cause and implementation approach documented in this issue file
+- [ ] Code and/or analysis updates committed in this PR
+- [ ] Verification evidence added (tests, logs, or artifact diffs)
+- [ ] Follow-up risks and limitations noted
 
-Refs #26
+## Implementation plan
+- [ ] Specify required sample-size cuts (overall + key subgroup breakdowns)
+- [ ] Implement computation of N, missing counts, and usable sample per analysis block
+- [ ] Add formatted sample-size table to EDA outputs/artifacts
+- [ ] Ensure table updates automatically when filters/preprocessing change
+- [ ] Add tests validating counts against fixture datasets
+\nRefs #26


### PR DESCRIPTION
Draft PR scaffold for issue #26.

This tracks implementation steps and will be updated with actual code changes.

Refs #26