### PR TITLE
Docs: clarify admin CLI prerequisites and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ Examples:
 - `python tools/repo_admin.py analysis run --step all`
 - `python tools/repo_admin.py mapping propose --version-id <id> --dry-run`
 - `python tools/repo_admin.py pipeline run --version-id <id> --dry-run`
+
+### Prerequisites by workflow
+
+- Analysis: Python env with `numpy`, `pandas`, `matplotlib`, `seaborn`, `scipy`, `statsmodels`.
+- Mapping propose: Vertex AI access, GCP auth, and active billing. Required env typically includes `GCP_PROJECT_ID`, `R2_*`, and credentials.
+- Pipeline and enrichment: `R2_*` env vars and bucket access.
+- Worker checks: `node` + `npm` available.
+- API commands: `WORKER_API_BASE` plus `WORKER_API_TOKEN` (and optional Cloudflare Access headers).
+
+### Troubleshooting
+
+- Run `python tools/repo_admin.py doctor --component all` before external workflows.
+- If mapping propose fails due billing/auth, use `--dry-run` to validate orchestration and then configure Vertex billing/permissions.
+- If API commands return auth errors, verify token + Access headers and call `python tools/repo_admin.py api list-runs`.

--- a/skills/master-thesis-admin/SKILL.md
+++ b/skills/master-thesis-admin/SKILL.md
@@ -37,3 +37,5 @@ Prefer this wrapper for reusable calls:
 - Run commands from any directory; the CLI resolves repository paths internally.
 - Use `--dry-run` for mapping/pipeline/cloud commands when credentials or billing are unavailable.
 - Run `doctor` before external workflows to detect missing env or dependencies.
+- Expect `mapping propose` to require Vertex billing and IAM permissions; do not treat billing/auth failures as code defects unless repro occurs with valid credentials.
+- Prefer `doctor --component mapping` before invoking mapping, and `doctor --component ui` before launching the Streamlit console.


### PR DESCRIPTION
## Summary
- document workflow prerequisites for the unified admin CLI in `README.md`
- add troubleshooting guidance for mapping billing/auth and Worker API auth failures
- clarify expected mapping behavior in skill instructions (`skills/master-thesis-admin/SKILL.md`)

## Validation
- `python3 tools/repo_admin.py --help`

Closes #46
