### PR TITLE
Chore: Pin analysis dependency versions

### DIFF
--- a/jobs/analysis/requirements.txt
+++ b/jobs/analysis/requirements.txt
@@ -1,6 +1,7 @@
-numpy
-pandas
-scipy
-statsmodels
-matplotlib
-seaborn
+# Pinned for thesis reproducibility (tested with Python 3.11/3.12)
+numpy==1.26.4
+pandas==2.2.3
+scipy==1.14.1
+statsmodels==0.14.4
+matplotlib==3.9.3
+seaborn==0.13.2


### PR DESCRIPTION
Fixes #50

Pins all analysis dependencies to specific versions for thesis reproducibility. Tested with Python 3.11/3.12.